### PR TITLE
Adding libiconv to dependencies

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,6 +29,7 @@ requirements:
     - libcurl
     - openssl
     - libarchive
+    - libiconv
     - nlohmann_json
   run:
     - python
@@ -58,3 +59,4 @@ extra:
     - SylvainCorlay
     - JohanMabille
     - wolfv
+    - ericmjl


### PR DESCRIPTION
When I installed mamba standalone, I got a “libiconv missing error”. I thus added libiconv to my environment, and it worked fine afterwards. I am proposing this PR to do two things:

- Add libiconv to dependencies
- Add myself as a recipe maintainer, because I’m a fan!

Please let me know if libiconv shouldn’t be in there, I’ll take it out.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
