### PR TITLE
Bump minimum conda version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
   sha256: 21e12253a8360b5e0199649ce4c66a2a9830f0cd83811d9527c57c72a2a4ec84
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: libmamba
@@ -123,7 +123,7 @@ outputs:
         - {{ pin_subpackage('libmambapy', exact=True) }}
       run:
         - python
-        - conda >=4.8,<23.4
+        - conda >=4.14,<23.4
         - {{ pin_subpackage('libmambapy', exact=True) }}
 
     test:


### PR DESCRIPTION
In pull request https://github.com/mamba-org/mamba/pull/2220, we switch from using function `check_whitelist` to `check_allowlist` while the latter has only available in conda>=4.14.0 (introduced in PR https://github.com/conda/conda/pull/11647).

In this PR, I raise the minimal version required by mamba to 4.14. I will open a repo data patch to make the same change to mamba 1.2.0, 1.3.0, and earlier builds of 1.3.1.

Fixes https://github.com/conda-forge/mamba-feedstock/issues/172 opened by @raydouglass.

Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
