### PR TITLE
Add a couple more CLI tests; test create on Unixes

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -142,7 +142,9 @@ outputs:
         - if exist %PREFIX%\condabin\mamba.bat (exit 0) else (exit 1)  # [win]
         - test -f ${PREFIX}/etc/profile.d/mamba.sh  # [linux]
         # these tests work when run on win, but for some reason not during conda build
-        - mamba create -n test_py2 python=2.7 --dry-run  # [linux]
+        - mamba create -n test_py2 python=2.7 --dry-run  # [unix]
+        - mamba clean --all --dry-run  # [unix]
+        - mamba repoquery whoneeds conda  # [unix]
         - mamba install xtensor xsimd -c conda-forge --dry-run  # [linux and x86_64]
         # for some reason tqdm doesn't have a proper colorama dependency so pip check fails
         # but that's completely unrelated to mamba


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->

This adds a couple of additional CLI tests.
-   `mamba clean` to test for https://github.com/mamba-org/mamba/issues/3033#issuecomment-1842002838 .
-   `mamba repoquery` to test for https://github.com/mamba-org/mamba/issues/2994 .

Also test `mamba create` on `osx-` targets.
(Leaving out Windows as per the code comment; would probably work with invoking the `.exe` directly or prepending `%PREFIX%\condabin` to `PATH` manually beforehand, though). 

Let's add these tests when a new version is released.
Adding it here as a "draft pull request" so we can just cherry-pick it.