### PR TITLE
Put `mamba` under `condabin/` too

### DIFF
--- a/recipe/build_mamba.bat
+++ b/recipe/build_mamba.bat
@@ -36,8 +36,7 @@ if /I "%PKG_NAME%" == "mamba" (
     cmake --build build-mamba/ --parallel %CPU_COUNT%
     if errorlevel 1 exit 1
     cmake --install build-mamba/
-    :: Place mamba executable copy to condabin/
-    mkdir "%PREFIX%\condabin"
-    echo ^"%LIBRARY_BIN%\mamba.exe^" %%* > "%PREFIX%\condabin\mamba.bat"
+    :: Install BAT hooks in condabin/
+    CALL "%LIBRARY_BIN%\mamba.exe" shell hook --shell cmd.exe "%PREFIX%"
     if errorlevel 1 exit 1
 )

--- a/recipe/build_mamba.bat
+++ b/recipe/build_mamba.bat
@@ -36,5 +36,8 @@ if /I "%PKG_NAME%" == "mamba" (
     cmake --build build-mamba/ --parallel %CPU_COUNT%
     if errorlevel 1 exit 1
     cmake --install build-mamba/
-
+    :: Place mamba executable copy to condabin/
+    mkdir "%PREFIX%\condabin"
+    copy /Y "%LIBRARY_PREFIX%\bin\mamba.exe" "%PREFIX%\condabin"
+    if errorlevel 1 exit 1
 )

--- a/recipe/build_mamba.bat
+++ b/recipe/build_mamba.bat
@@ -38,6 +38,6 @@ if /I "%PKG_NAME%" == "mamba" (
     cmake --install build-mamba/
     :: Place mamba executable copy to condabin/
     mkdir "%PREFIX%\condabin"
-    copy /Y "%LIBRARY_PREFIX%\bin\mamba.exe" "%PREFIX%\condabin"
+    echo ^"%LIBRARY_BIN%\mamba.exe^" %%* > "%PREFIX%\condabin\mamba.bat"
     if errorlevel 1 exit 1
 )

--- a/recipe/build_mamba.sh
+++ b/recipe/build_mamba.sh
@@ -34,4 +34,7 @@ elif [[ $PKG_NAME == "mamba" ]]; then
     cmake --build build-mamba/ --parallel ${CPU_COUNT}
     cmake --install build-mamba/
 
+    # Add symlink to condabin
+    mkdir -p "${PREFIX}/condabin"
+    ln -s "${PREFIX}/bin/mamba" "${PREFIX}/condabin/mamba"
 fi

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -161,9 +161,13 @@ outputs:
     test:
       commands:
         - test -f "${PREFIX}/bin/mamba"                  # [unix]
+        - test -f "${PREFIX}/condabin/mamba"             # [unix]
         - test -f "${PREFIX}/etc/profile.d/mamba.sh"     # [unix]
         - if not exist %LIBRARY_BIN%\mamba.exe (exit 1)  # [win]
+        - if not exist %PREFIX%\condabin\mamba.bat (exit 1)  # [win]
         - mamba --help
+        - "${PREFIX}/condabin/mamba" --help        # [unix]
+        - "%PREFIX%/condabin/mamba.bat" --help     # [win]
         - export MAMBA_ROOT_PREFIX="$(mktemp -d)"  # [unix]
         - mkdir %TEMP%\mamba                       # [win]
         - set "MAMBA_ROOT_PREFIX=%TEMP%\mamba"     # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha256: bee1cbd4c499ef3ed020f9ce152b722b8e30e69a8b25abaa116673ebda833875
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: libmamba

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -166,8 +166,8 @@ outputs:
         - if not exist %LIBRARY_BIN%\mamba.exe (exit 1)  # [win]
         - if not exist %PREFIX%\condabin\mamba.bat (exit 1)  # [win]
         - mamba --help
-        - "${PREFIX}/condabin/mamba" --help        # [unix]
-        - "%PREFIX%/condabin/mamba.bat" --help     # [win]
+        - ${PREFIX}/condabin/mamba --help          # [unix]
+        - CALL %PREFIX%/condabin/mamba.bat --help       # [win]
         - export MAMBA_ROOT_PREFIX="$(mktemp -d)"  # [unix]
         - mkdir %TEMP%\mamba                       # [win]
         - set "MAMBA_ROOT_PREFIX=%TEMP%\mamba"     # [win]

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -13,7 +13,7 @@ source:
   sha256: 90e31a0aabc2422685628b23720fdfd4dd5b50827258afeab5500effe250f799
 
 build:
-  number: 1
+  number: 2
 
 outputs:
   - name: libmamba


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->


Some users have `$PREFIX/condabin` in `PATH`, and updating to mamba 2.0 breaks their workflows because it's only putting the executable under `bin/`, which results in errors like `executable not found` etc. See https://github.com/conda-incubator/setup-miniconda/actions/runs/11083642307/job/30798086717?pr=367#step:3:906.