### PR TITLE
[1.x] Rebuild for fmt 11 and spdlog 1.14

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fmt:
-- '10'
+- '11'
 libarchive:
 - '3.7'
 openssl:
@@ -32,7 +32,7 @@ python:
 - 3.12.* *_cpython
 - 3.9.* *_cpython
 spdlog:
-- '1.12'
+- '1.14'
 target_platform:
 - linux-64
 zip_keys:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -19,7 +19,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fmt:
-- '10'
+- '11'
 libarchive:
 - '3.7'
 openssl:
@@ -36,7 +36,7 @@ python:
 - 3.12.* *_cpython
 - 3.9.* *_cpython
 spdlog:
-- '1.12'
+- '1.14'
 target_platform:
 - linux-aarch64
 zip_keys:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -15,7 +15,7 @@ cxx_compiler_version:
 docker_image:
 - quay.io/condaforge/linux-anvil-cos7-x86_64
 fmt:
-- '10'
+- '11'
 libarchive:
 - '3.7'
 openssl:
@@ -32,7 +32,7 @@ python:
 - 3.12.* *_cpython
 - 3.9.* *_cpython
 spdlog:
-- '1.12'
+- '1.14'
 target_platform:
 - linux-ppc64le
 zip_keys:

--- a/.ci_support/migrations/fmt11.yaml
+++ b/.ci_support/migrations/fmt11.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for fmt 11
+  kind: version
+  migration_number: 1
+fmt:
+- '11'
+migrator_ts: 1720374637.828791

--- a/.ci_support/migrations/spdlog114.yaml
+++ b/.ci_support/migrations/spdlog114.yaml
@@ -1,0 +1,8 @@
+__migrator:
+  build_number: 1
+  commit_message: Rebuild for spdlog 1.14
+  kind: version
+  migration_number: 1
+migrator_ts: 1722204008.301365
+spdlog:
+- '1.14'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 fmt:
-- '10'
+- '11'
 libarchive:
 - '3.7'
 macos_machine:
@@ -34,7 +34,7 @@ python:
 - 3.12.* *_cpython
 - 3.9.* *_cpython
 spdlog:
-- '1.12'
+- '1.14'
 target_platform:
 - osx-64
 zstd:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -15,7 +15,7 @@ cxx_compiler:
 cxx_compiler_version:
 - '17'
 fmt:
-- '10'
+- '11'
 libarchive:
 - '3.7'
 macos_machine:
@@ -34,7 +34,7 @@ python:
 - 3.12.* *_cpython
 - 3.9.* *_cpython
 spdlog:
-- '1.12'
+- '1.14'
 target_platform:
 - osx-arm64
 zstd:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -7,7 +7,7 @@ channel_targets:
 cxx_compiler:
 - vs2019
 fmt:
-- '10'
+- '11'
 libarchive:
 - '3.7'
 openssl:
@@ -24,7 +24,7 @@ python:
 - 3.12.* *_cpython
 - 3.9.* *_cpython
 spdlog:
-- '1.12'
+- '1.14'
 target_platform:
 - win-64
 zstd:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,7 +14,7 @@ source:
   sha256: becf78997707b4bf42049f62ed1a1c5554bbeacb2e29d6eb852de10063eeef6e
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: libmamba


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
We are running into awkward issues with RAPIDS, which uses fmt and spdlog in many packages. We need to keep to libmambapy <2 for our immediate release, but the existing 1.x builds use older fmt and spdlog pins. This PR is intended to rebuild the latest 1.x release with newer fmt and spdlog.