### PR TITLE
Remove `libmamba`'s `pin_compatible` specifications in `run`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -108,7 +108,7 @@ outputs:
         - python
         - scikit-build
         - pip
-        - setuptools
+        - setuptools <79
         - pybind11
         - pybind11-abi
         - openssl

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -35,7 +35,7 @@ outputs:
         - libcurl >=8.4.0
         - openssl
         - libarchive
-        - nlohmann_json
+        - nlohmann_json <3.12
         - cpp-expected
         - reproc
         - reproc-cpp >=14.2.4.post0
@@ -117,7 +117,7 @@ outputs:
         - spdlog
         - fmt
         - termcolor-cpp
-        - nlohmann_json
+        - nlohmann_json <3.12
         - {{ pin_subpackage('libmamba', exact=True) }}
         # zstd is not a direct dependency but this specification is needed to
         # distinguish builds of libmambapy for specific specific version of zstd.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -47,8 +47,19 @@ outputs:
         - zstd
         - simdjson >=3.3.0
       run:
-        - {{ pin_compatible('cpp-expected', exact=True) }}
+        # `nlohmann_json` is pinned because we expose it in the API of libmamba
+        # (`nlohmann_json` objects are put in version namespaces because the author
+        # does not want to take any risk regarding ABI compatibility)
+        #
+        # Since `nlohmann_json` is a heaer only library, it does not have run_export,
+        # and we don't have the choice, we need to pin it here exactly
+        #
+        # Therefore, any library exchanging `nlohmann_json` objects with libmamba
+        # must be built with exactly the same version of nlohmann_json as that
+        # used to build mamba.
         - {{ pin_compatible('nlohmann_json', exact=True) }}
+        # Similar reasons apply to `cpp-expected`.
+        - {{ pin_compatible('cpp-expected', exact=True) }}
 
     test:
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 8e8dd36a6d974a41d3bcd498f0b4f38092b25ed372d954e1721073e49fea9466
 
 build:
-  number: 0
+  number: 1
 
 outputs:
   - name: libmamba
@@ -46,17 +46,6 @@ outputs:
         - winreg                                 # [win]
         - zstd
         - simdjson >=3.3.0
-      run:
-        # Missing run_export in libsolv
-        - {{ pin_compatible('libsolv', max_pin='x.x.x') }}
-        # Public libmamba dependencies
-        - {{ pin_compatible('fmt', max_pin='x.x') }}
-        - {{ pin_compatible('spdlog', max_pin='x.x') }}
-        - {{ pin_compatible('cpp-expected', max_pin='x.x') }}
-        - {{ pin_compatible('nlohmann_json', max_pin='x.x') }}
-        - {{ pin_compatible('yaml-cpp', max_pin='x.x') }}
-        - {{ pin_compatible('reproc', max_pin='x.x') }}
-        - {{ pin_compatible('reproc-cpp', max_pin='x.x') }}
 
     test:
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -57,9 +57,9 @@ outputs:
         # Therefore, any library exchanging `nlohmann_json` objects with libmamba
         # must be built with exactly the same version of nlohmann_json as that
         # used to build mamba.
-        - {{ pin_compatible('nlohmann_json', exact=True) }}
+        - {{ pin_compatible('nlohmann_json', max_pin='x.x.x') }}
         # Similar reasons apply to `cpp-expected`.
-        - {{ pin_compatible('cpp-expected', exact=True) }}
+        - {{ pin_compatible('cpp-expected', max_pin='x.x.x') }}
 
     test:
       commands:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -46,6 +46,9 @@ outputs:
         - winreg                                 # [win]
         - zstd
         - simdjson >=3.3.0
+      run:
+        - {{ pin_compatible('cpp-expected', exact=True) }}
+        - {{ pin_compatible('nlohmann_json', exact=True) }}
 
     test:
       commands:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Continue https://github.com/conda-forge/mamba-feedstock/pull/238.

To be rerun and merged after https://github.com/conda-forge/libsolv-feedstock/pull/103.

We can rely on the dependencies' `run_export` directly.

See the comment bellow.

---

@conda-forge-admin, please rerender