### PR TITLE
[`prerelease`] Remove variants on `pybind11{,_abi}`

### DIFF
--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -24,6 +24,10 @@ pybind11_abi:
 - '4'
 python:
 - 3.10.* *_cpython
+- 3.11.* *_cpython
+- 3.12.* *_cpython
+- 3.13.* *_cp313
+- 3.14.* *_cp314
 python_min:
 - '3.10'
 spdlog:

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -20,10 +20,8 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
-pybind11:
-- 2
 pybind11_abi:
-- 4
+- '4'
 python:
 - 3.10.* *_cpython
 python_min:
@@ -32,8 +30,5 @@ spdlog:
 - '1.17'
 target_platform:
 - linux-64
-zip_keys:
-- - pybind11
-  - pybind11_abi
 zstd:
 - '1.5'

--- a/.ci_support/linux_64_.yaml
+++ b/.ci_support/linux_64_.yaml
@@ -24,10 +24,6 @@ pybind11_abi:
 - '4'
 python:
 - 3.10.* *_cpython
-- 3.11.* *_cpython
-- 3.12.* *_cpython
-- 3.13.* *_cp313
-- 3.14.* *_cp314
 python_min:
 - '3.10'
 spdlog:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -24,6 +24,10 @@ pybind11_abi:
 - '4'
 python:
 - 3.10.* *_cpython
+- 3.11.* *_cpython
+- 3.12.* *_cpython
+- 3.13.* *_cp313
+- 3.14.* *_cp314
 python_min:
 - '3.10'
 spdlog:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -24,10 +24,6 @@ pybind11_abi:
 - '4'
 python:
 - 3.10.* *_cpython
-- 3.11.* *_cpython
-- 3.12.* *_cpython
-- 3.13.* *_cp313
-- 3.14.* *_cp314
 python_min:
 - '3.10'
 spdlog:

--- a/.ci_support/linux_aarch64_.yaml
+++ b/.ci_support/linux_aarch64_.yaml
@@ -20,10 +20,8 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
-pybind11:
-- 2
 pybind11_abi:
-- 4
+- '4'
 python:
 - 3.10.* *_cpython
 python_min:
@@ -32,8 +30,5 @@ spdlog:
 - '1.17'
 target_platform:
 - linux-aarch64
-zip_keys:
-- - pybind11
-  - pybind11_abi
 zstd:
 - '1.5'

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -20,10 +20,8 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
-pybind11:
-- 2
 pybind11_abi:
-- 4
+- '4'
 python:
 - 3.10.* *_cpython
 python_min:
@@ -32,8 +30,5 @@ spdlog:
 - '1.17'
 target_platform:
 - linux-ppc64le
-zip_keys:
-- - pybind11
-  - pybind11_abi
 zstd:
 - '1.5'

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -24,6 +24,10 @@ pybind11_abi:
 - '4'
 python:
 - 3.10.* *_cpython
+- 3.11.* *_cpython
+- 3.12.* *_cpython
+- 3.13.* *_cp313
+- 3.14.* *_cp314
 python_min:
 - '3.10'
 spdlog:

--- a/.ci_support/linux_ppc64le_.yaml
+++ b/.ci_support/linux_ppc64le_.yaml
@@ -24,10 +24,6 @@ pybind11_abi:
 - '4'
 python:
 - 3.10.* *_cpython
-- 3.11.* *_cpython
-- 3.12.* *_cpython
-- 3.13.* *_cp313
-- 3.14.* *_cp314
 python_min:
 - '3.10'
 spdlog:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -24,10 +24,8 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
-pybind11:
-- 2
 pybind11_abi:
-- 4
+- '4'
 python:
 - 3.10.* *_cpython
 python_min:
@@ -36,8 +34,5 @@ spdlog:
 - '1.17'
 target_platform:
 - osx-64
-zip_keys:
-- - pybind11
-  - pybind11_abi
 zstd:
 - '1.5'

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -28,10 +28,6 @@ pybind11_abi:
 - '4'
 python:
 - 3.10.* *_cpython
-- 3.11.* *_cpython
-- 3.12.* *_cpython
-- 3.13.* *_cp313
-- 3.14.* *_cp314
 python_min:
 - '3.10'
 spdlog:

--- a/.ci_support/osx_64_.yaml
+++ b/.ci_support/osx_64_.yaml
@@ -28,6 +28,10 @@ pybind11_abi:
 - '4'
 python:
 - 3.10.* *_cpython
+- 3.11.* *_cpython
+- 3.12.* *_cpython
+- 3.13.* *_cp313
+- 3.14.* *_cp314
 python_min:
 - '3.10'
 spdlog:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -28,10 +28,6 @@ pybind11_abi:
 - '4'
 python:
 - 3.10.* *_cpython
-- 3.11.* *_cpython
-- 3.12.* *_cpython
-- 3.13.* *_cp313
-- 3.14.* *_cp314
 python_min:
 - '3.10'
 spdlog:

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -24,10 +24,8 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
-pybind11:
-- 2
 pybind11_abi:
-- 4
+- '4'
 python:
 - 3.10.* *_cpython
 python_min:
@@ -36,8 +34,5 @@ spdlog:
 - '1.17'
 target_platform:
 - osx-arm64
-zip_keys:
-- - pybind11
-  - pybind11_abi
 zstd:
 - '1.5'

--- a/.ci_support/osx_arm64_.yaml
+++ b/.ci_support/osx_arm64_.yaml
@@ -28,6 +28,10 @@ pybind11_abi:
 - '4'
 python:
 - 3.10.* *_cpython
+- 3.11.* *_cpython
+- 3.12.* *_cpython
+- 3.13.* *_cp313
+- 3.14.* *_cp314
 python_min:
 - '3.10'
 spdlog:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -18,10 +18,6 @@ pybind11_abi:
 - '4'
 python:
 - 3.10.* *_cpython
-- 3.11.* *_cpython
-- 3.12.* *_cpython
-- 3.13.* *_cp313
-- 3.14.* *_cp314
 python_min:
 - '3.10'
 spdlog:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -18,6 +18,10 @@ pybind11_abi:
 - '4'
 python:
 - 3.10.* *_cpython
+- 3.11.* *_cpython
+- 3.12.* *_cpython
+- 3.13.* *_cp313
+- 3.14.* *_cp314
 python_min:
 - '3.10'
 spdlog:

--- a/.ci_support/win_64_.yaml
+++ b/.ci_support/win_64_.yaml
@@ -14,10 +14,8 @@ pin_run_as_build:
   python:
     min_pin: x.x
     max_pin: x.x
-pybind11:
-- 2
 pybind11_abi:
-- 4
+- '4'
 python:
 - 3.10.* *_cpython
 python_min:
@@ -26,9 +24,6 @@ spdlog:
 - '1.17'
 target_platform:
 - win-64
-zip_keys:
-- - pybind11
-  - pybind11_abi
 zlib:
 - '1'
 zstd:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -1,6 +1,6 @@
 context:
   version: "2.9.0.rc0"
-  build_number: 0
+  build_number: 1
 
 recipe:
   name: mamba-split

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -167,11 +167,13 @@ outputs:
       skip: env.exists('CI') and not (linux and x86_64)
     requirements:
       host:
-        - python >=${{ python_min }}
+        - python ${{ python_min }}.*
         - pip
         - setuptools
         - mypy
         - libmambapy ==${{ version }}
+      run:
+        - python >=${{ python_min }}
       run_constraints:
         - libmambapy ==${{ version }}
     tests:

--- a/recipe/variants.yaml
+++ b/recipe/variants.yaml
@@ -1,10 +1,2 @@
-pybind11:
-  - 2
-  - 3
-pybind11_abi:
-  - 4
-  - 11
-zip_keys:
-  - [pybind11, pybind11_abi]
 channel_targets:
   - conda-forge mamba_prerelease


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Those variants were useful to help with transitioning to a new major version of `pybind11` (`pybind11` 3 at that time), but they might be constraining the recipe now (e.g. not allowing most python versions for the builds).

This PR removes those variants and also adapt `python` specifications (allowing the recipe to build for all the latest python minor versions).